### PR TITLE
Add terraform script to create VM instance hosting maqui

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,63 @@ Events and record attributes are stored respectively in [event.csv](https://gith
 
 The current prototype should work fine for data sets that contain 100,000 to 200,000 events and a few hundreds event types for an attribute. We are working on making MAQUI more scalable:)
 
+## Running MAQUI on a Flask server using Terraform on Google Cloud Platform
+
+Some of our colleagues aren't on developer laptops so couldn't make use of MAQUI. 
+We can use the cloud to provide a Software as a Service solution (SaaS). 
+We build a MVP using Terraform's Hashicorp Configuration Language (HCL) so that we can capture our infrastructure as code (IaS).   
+ 
+We followed [this documentation](https://cloud.google.com/community/tutorials/getting-started-on-gcp-with-terraform) to get started.
+ We installed [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) and created a new service account key with a role that has
+  Compute Admin permissions.
+   We created a configuration file called `main.tf`, read the comments in this file for what each bit does. 
+   We also had to change the region and zone and used this [tool](https://cloud.google.com/compute/docs/regions-zones) to help with that. 
+   We tweaked a few other things such as firewall rules and enabling guest attributes. 
+   
+There's a file called `terraform.tfvars.example` that demonstrates how terraform makes use of variables. Change the filename to just `terraform.tfvars`
+ and provide the correct variable information (i.e. key locations, project name and your machine's username). 
+ You'll need a GCP service account json access key with appropriate permissions (as described above) in the `.secrets` folder (create the folder in the root directory). 
+ You'll need your RSA public key in `~/.ssh/id_rsa.pub` (enter your machine's username to your newly created `terraform.tfvars` file).  
+ 
+ If you get stuck try consulting Google's or Hashicorp's docs which are comprehensive.
+
+### Using Terraform for the first time
+After installing terraform, you should run:
+
+`terraform init` to download relevant plugins.  
+
+`terraform plan`   
+
+`terraform apply` to launch the plan, followed by 'yes' to create instance.  
+
+You can then create a [simple 'Hello World' Flask app](https://flask.palletsprojects.com/en/2.0.x/quickstart/) to check everything works
+ (go to the [GCP VM instances page](https://console.cloud.google.com/compute/instances) to find your instance,
+  SSH in and deploy the app following the instructions, you'll need another shell to check the Flask app is working).  
+
+When you're done use `terraform destroy` to remove all resources defined during configuration. 
+
+### Using Terraform to build and configure instance for MAQUI flask app 
+
+You have everything on the instance you need to run MAQUI. The git clone step of the MAQUI repo might have failed,
+ rerun it (i.e. ensure alphagov/MAQUI repo is on the instance `git clone https://github.com/alphagov/MAQUI.git`). 
+ 
+ You'll need the data you want to explore in the `data` folder,
+  you can [transfer files using SSH in the browser](https://cloud.google.com/compute/docs/instances/transfer-files#transferbrowser).
+   You'll need both `events.csv` and `recordAttributes.csv` in there.  
+   
+   You are now ready to start the app. Go to the `server` folder 
+and run `python3 server.py` to start the flask app for MAQUI. This points to port 5000. 
+
+### Connect to the app from your own machine so that you can use it's sofware (i.e. Chrome)  
+With the instance created and the flask app running, we can use [port forwarding](https://cloud.google.com/solutions/connecting-securely#port-forwarding-over-ssh)
+ to connect to it through ssh on our local machine. We can use the [Google Command Line interface / SDK](https://cloud.google.com/sdk/docs/downloads-interactive) to ssh to the instance. 
+ With that installed on our local machine we can run the `port_forwarding_example` script in the command line but ensuring we have the correct Virtual Machine name.
+ 
+ We specify a local port of '2222' and a remote port of '5000' (Flask's default), and you open [localhost:2222/]() in your Chrome browser,
+  the HTTP connection uses the SSH tunnel that you created to your remote host to connect to the specified VM instance using SSH.
+   The HTTP connection will then use the SSH tunnel to connect to port 5000 on the same machine, but over an encrypted,
+    secure SSH connection. 
+    
 ## Acknowledgements
 
 This was forked from a project by [Terrance Law](https://terrancelaw.github.io).

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+.secrets/*
+.secrets/

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,73 @@
+// Configure environment variables, specify default variable and type
+variable "gcp_credentials_path" {
+ type = string
+}
+
+variable "username" {
+ type = string
+}
+
+variable "project" {
+ type = string
+}
+
+// Configure the Google Cloud provider
+provider "google" {
+ credentials = file(var.gcp_credentials_path)
+ project     = "${var.project}"
+ region      = "europe-west2"
+}
+
+// Terraform plugin for creating random ids
+resource "random_id" "instance_id" {
+ byte_length = 8
+}
+
+// A single Compute Engine instance
+resource "google_compute_instance" "default" {
+ name         = "flask-vm-${random_id.instance_id.hex}"
+ machine_type = "f1-micro"
+ zone         = "europe-west2-b"
+ // Add SSH access to the Compute Engine Instance from instance creator
+ // Enable guest attributes
+ // Users will need a role with `compute.instances.getGuestAttributes` permission; use GCP IAM to grant
+ metadata = {
+    ssh-keys = "${var.username}:${file("~/.ssh/id_rsa.pub")}"
+    enable-guest-attributes = "TRUE"
+  }
+
+ boot_disk {
+   initialize_params {
+     image = "debian-cloud/debian-9"
+   }
+ }
+
+// Make sure flask is installed on all new instances for later steps
+// Also add git so we can git clone alphagov/MAQUI
+// MAQUI requires python3 to run properly, so we install pip3 and pip3 install flask
+// MAQUI also needs java, hence default-jre
+ metadata_startup_script = "sudo apt-get update; sudo apt-get install -yq build-essential python-pip rsync; pip install flask; sudo apt-get install git --yes; git clone https://github.com/alphagov/MAQUI.git; sudo apt install python3-pip --yes; sudo pip3 install flask; sudo apt install default-jre --yes"
+
+ network_interface {
+   network = "default"
+
+   access_config {
+     // Include this section to give the VM an external ip address
+   }
+ }
+}
+
+// A variable for extracting the external IP address of the instance
+ output "ip" {
+  value = google_compute_instance.default.network_interface.0.access_config.0.nat_ip
+}
+
+resource "google_compute_firewall" "default" {
+ name    = "flask-app-firewall"
+ network = "default"
+
+ allow {
+   protocol = "tcp"
+   ports    = ["5000"]
+ }
+}

--- a/port_forwarding_example
+++ b/port_forwarding_example
@@ -1,0 +1,4 @@
+gcloud compute ssh VM_NAME \
+    --project PROJECT_NAME \
+    --zone europe-west2-b \
+    -- -NL 2222:localhost:5000

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,5 @@
+gcp_credentials_path = ".secrets/key_filename.json"
+
+username = "joebloggs"
+
+project = "my-project"


### PR DESCRIPTION
Software as a service, a flask app that helps users mine patterns and visualise user journey data.

Using Terraform's hashicorp configuration language to create an virtual machine instance on google cloud platform with the dependencies to run MAQUI, a flask app.